### PR TITLE
Support for unrestricted access to kube-apiservers

### DIFF
--- a/pykube/config.py
+++ b/pykube/config.py
@@ -115,7 +115,10 @@ class KubeConfig(object):
         Returns known users by exposing as a read-only property.
         """
         if not hasattr(self, "_users"):
-            us = { "default": {} }
+            us = {
+                "default": {}
+            }
+
             if "users" in self.doc:
                 for ur in self.doc["users"]:
                     us[ur["name"]] = u = copy.deepcopy(ur["user"])

--- a/pykube/config.py
+++ b/pykube/config.py
@@ -115,12 +115,14 @@ class KubeConfig(object):
         Returns known users by exposing as a read-only property.
         """
         if not hasattr(self, "_users"):
-            us = {}
-            for ur in self.doc["users"]:
-                us[ur["name"]] = u = copy.deepcopy(ur["user"])
-                BytesOrFile.maybe_set(u, "client-certificate")
-                BytesOrFile.maybe_set(u, "client-key")
+            us = { "default": {} }
+            if "users" in self.doc:
+                for ur in self.doc["users"]:
+                    us[ur["name"]] = u = copy.deepcopy(ur["user"])
+                    BytesOrFile.maybe_set(u, "client-certificate")
+                    BytesOrFile.maybe_set(u, "client-key")
             self._users = us
+
         return self._users
 
     @property
@@ -152,7 +154,11 @@ class KubeConfig(object):
         """
         if self.current_context is None:
             raise exceptions.PyKubeError("current context not set; call set_current_context")
-        return self.users[self.contexts[self.current_context]["user"]]
+
+        context = self.contexts[self.current_context]
+        current_user = context["user"]
+
+        return self.users[current_user]
 
 
 class BytesOrFile(object):

--- a/pykube/http.py
+++ b/pykube/http.py
@@ -34,11 +34,12 @@ class HTTPClient(object):
             s.verify = self.config.cluster["certificate-authority"].filename()
         if "token" in self.config.user and self.config.user["token"]:
             s.headers["Authorization"] = "Bearer {}".format(self.config.user["token"])
-        else:
+        elif "client-certificate" in self.config.user and self.config.user["client-certificate"]:
             s.cert = (
                 self.config.user["client-certificate"].filename(),
                 self.config.user["client-key"].filename(),
             )
+
         return s
 
     def get_kwargs(self, **kwargs):

--- a/pykube/http.py
+++ b/pykube/http.py
@@ -32,9 +32,10 @@ class HTTPClient(object):
         s = requests.Session()
         if "certificate-authority" in self.config.cluster:
             s.verify = self.config.cluster["certificate-authority"].filename()
+
         if "token" in self.config.user and self.config.user["token"]:
             s.headers["Authorization"] = "Bearer {}".format(self.config.user["token"])
-        elif "client-certificate" in self.config.user and self.config.user["client-certificate"]:
+        elif "client-certificate" in self.config.user:
             s.cert = (
                 self.config.user["client-certificate"].filename(),
                 self.config.user["client-key"].filename(),

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -10,7 +10,7 @@ from . import TestCase
 
 
 GOOD_CONFIG_FILE_PATH = os.path.sep.join(["test", "test_config.yaml"])
-
+DEFAULTUSER_CONFIG_FILE_PATH = os.path.sep.join(["test", "test_config_default_user.yaml"])
 
 class TestConfig(TestCase):
 
@@ -101,3 +101,11 @@ class TestConfig(TestCase):
 
         self.cfg.set_current_context("thename")
         self.assertEqual("data", self.cfg.user)
+
+    def test_default_user(self):
+        """
+        User can sometimes be specified as 'default' with no corresponding definition
+        """
+        test_config = config.KubeConfig.from_file(DEFAULTUSER_CONFIG_FILE_PATH)
+        test_config.set_current_context("a_context")
+        self.assertIsNotNone(test_config.user)

--- a/test/test_config_default_user.yaml
+++ b/test/test_config_default_user.yaml
@@ -1,0 +1,8 @@
+clusters:
+    - name: a_cluster
+      cluster: {}
+contexts:
+    - name: a_context
+      context:
+        cluster: a_cluster
+        user: default

--- a/test/test_httpclient.py
+++ b/test/test_httpclient.py
@@ -12,7 +12,7 @@ class TestHTTPClient(TestCase):
 
     def test_no_auth(self):
         """
-        Ensure headers are set for certificate based auth
+        Cluster does not require any authentication--so no credentials are provided in the user info
         """
         client = http.HTTPClient(config.KubeConfig(doc=self.sampleNoAuthConfig))
 

--- a/test/test_httpclient.py
+++ b/test/test_httpclient.py
@@ -1,0 +1,47 @@
+"""
+pykube.http unittests
+"""
+
+import os
+
+from pykube import http, config
+
+from . import TestCase
+
+class TestHTTPClient(TestCase):
+
+    def test_no_auth(self):
+        """
+        Ensure headers are set for certificate based auth
+        """
+        client = http.HTTPClient(config.KubeConfig(doc=self.sampleNoAuthConfig))
+
+        self.assertIsNone(client.session.cert, msg="Should not send certs when not configured")
+        self.assertNotIn("Authorization", client.session.headers, msg="Should not send basic auth when not configured")
+
+    sampleNoAuthConfig = {
+        "clusters": [
+            {
+                "name": "no-auth-cluster",
+                "cluster": {
+                    "server": "http://localhost:8080",
+                }
+            }
+        ],
+        "users": [
+            {
+                "name": "no-auth-cluster",
+                "user": {}
+            }
+        ],
+        "contexts": [
+            {
+                "name": "no-auth-cluster",
+                "context": {
+                    "cluster": "no-auth-cluster",
+                    "user": "no-auth-cluster"
+                }
+            }
+        ],
+        "current-context": "no-auth-cluster"
+    }


### PR DESCRIPTION
Allows me to query kube-api when there is not auth required.  Do I need to up the version in setup.py or do you manage that separately with your release process? (i'm new to python ecosystem)