### PR TITLE
Scale method for jobs

### DIFF
--- a/pykube/objects.py
+++ b/pykube/objects.py
@@ -148,6 +148,21 @@ class Job(NamespacedAPIObject):
     endpoint = "jobs"
     kind = "Job"
 
+    def scale(self, replicas=None):
+        """Scales a job as it would be done by kubectl scale --replicas=num Jobs/myjob. Replicas can start from zero."""
+        parallelism = replicas
+        # we use parallelism from now on because this is what it is altered at the API level by the kubectl call
+        if parallelism is None:
+            parallelism = self.obj['spec']['parallelism']
+        self.exists(ensure=True)
+        self.obj['spec']['parallelism'] = parallelism
+        self.update()
+        while True:
+            self.reload()
+            if self.self.obj['spec']['parallelism'] == parallelism:
+                break
+            time.sleep(1)
+
 
 class Namespace(APIObject):
 

--- a/pykube/objects.py
+++ b/pykube/objects.py
@@ -153,13 +153,13 @@ class Job(NamespacedAPIObject):
         parallelism = replicas
         # we use parallelism from now on because this is what it is altered at the API level by the kubectl call
         if parallelism is None:
-            parallelism = self.obj['spec']['parallelism']
+            parallelism = self.obj["spec"]["parallelism"]
         self.exists(ensure=True)
-        self.obj['spec']['parallelism'] = parallelism
+        self.obj["spec"]["parallelism"] = parallelism
         self.update()
         while True:
             self.reload()
-            if self.self.obj['spec']['parallelism'] == parallelism:
+            if self.self.obj["spec"]["parallelism"] == parallelism:
                 break
             time.sleep(1)
 


### PR DESCRIPTION
In the current state of the k8s API, Jobs can be scaled as pods are, but the mechanism of scaling is different in terms of how the API objects are changed. This doesn't allow Job to inherit from ReplicatedAPIObject or share the same method as scale of the replication controller. Scaling of Jobs on kubernetes currently going through setting the parallelism of the Job object. Follows the same logic as the scale method of replication controller.