### PR TITLE
Feature/pod logs

### DIFF
--- a/pykube/http.py
+++ b/pykube/http.py
@@ -63,6 +63,11 @@ class HTTPClient(object):
                 "namespaces",
                 kwargs.pop("namespace"),
             ])
+        if "pods" in kwargs:
+            bits.extend([
+                "pods",
+                kwargs.pop("pods")
+            ])
         url = kwargs.get("url", "")
         if url.startswith("/"):
             url = url[1:]

--- a/pykube/objects.py
+++ b/pykube/objects.py
@@ -4,7 +4,7 @@ import time
 
 import jsonpatch
 
-from urllib import urlencode
+from six.moves.urllib.parse import urlencode
 from .exceptions import ObjectDoesNotExist
 from .query import ObjectManager
 

--- a/pykube/objects.py
+++ b/pykube/objects.py
@@ -176,20 +176,36 @@ class Pod(NamespacedAPIObject):
         condition = next((c for c in cs if c["type"] == "Ready"), None)
         return condition is not None and condition["status"] == "True"
 
-    def get_logs(self, container=None):
-        url = "logs"
+    def get_logs(self, container=None, pretty=None, previous=False,
+                 since_seconds=None, since_time=None, timestamps=False,
+                 tail_lines=None, limit_bytes=None):
+        """Produces the same result as calling kubectl logs pod/<pod-name>"""
+        url = "log"
         params = {}
         if container is not None:
             params["container"] = container
+        if pretty is not None:
+            params["pretty"] = pretty
+        if previous:
+            params["previous"] = "true"
+        if since_seconds is not None and since_time is None:
+            params["sinceSeconds"] = int(since_seconds)
+        elif since_time is not None and since_seconds is None:
+            params["sinceTime"] = since_time
+        if timestamps:
+            params["timestamps"] = "true"
+        if tail_lines is not None:
+            params["tailLines"] = int(tail_lines)
+        if limit_bytes is not None:
+            params["limitBytes"] = int(limit_bytes)
+
         query_string = urlencode(params)
         url += "?{}".format(query_string) if query_string else ""
-        kwargs = {'url': url,
-                  'pods': self.name,
-                  'namespace': self.namespace,
-                  'version': self.version}
+        kwargs = {'url': url, 'pods': self.name,
+                  'namespace': self.namespace, 'version': self.version}
         r = self.api.get(**kwargs)
         r.raise_for_status()
-        return r.json()
+        return r.text
 
 
 class ReplicationController(NamespacedAPIObject, ReplicatedAPIObject):

--- a/pykube/objects.py
+++ b/pykube/objects.py
@@ -179,7 +179,11 @@ class Pod(NamespacedAPIObject):
     def get_logs(self, container=None, pretty=None, previous=False,
                  since_seconds=None, since_time=None, timestamps=False,
                  tail_lines=None, limit_bytes=None):
-        """Produces the same result as calling kubectl logs pod/<pod-name>"""
+        """
+        Produces the same result as calling kubectl logs pod/<pod-name>.
+        Check parameters meaning at http://kubernetes.io/docs/api-reference/v1/operations/,
+        part 'read log of the specified Pod'. The result is plain text.
+        """
         url = "log"
         params = {}
         if container is not None:

--- a/pykube/objects.py
+++ b/pykube/objects.py
@@ -205,8 +205,8 @@ class Pod(NamespacedAPIObject):
 
         query_string = urlencode(params)
         url += "?{}".format(query_string) if query_string else ""
-        kwargs = {'url': url, 'pods': self.name,
-                  'namespace': self.namespace, 'version': self.version}
+        kwargs = {"url": url, "pods": self.name,
+                  "namespace": self.namespace, "version": self.version}
         r = self.api.get(**kwargs)
         r.raise_for_status()
         return r.text

--- a/pykube/objects.py
+++ b/pykube/objects.py
@@ -176,7 +176,7 @@ class Pod(NamespacedAPIObject):
         condition = next((c for c in cs if c["type"] == "Ready"), None)
         return condition is not None and condition["status"] == "True"
 
-    def get_logs(self, container=None, pretty=None, previous=False,
+    def logs(self, container=None, pretty=None, previous=False,
                  since_seconds=None, since_time=None, timestamps=False,
                  tail_lines=None, limit_bytes=None):
         """

--- a/pykube/objects.py
+++ b/pykube/objects.py
@@ -166,6 +166,7 @@ class Pod(NamespacedAPIObject):
         condition = next((c for c in cs if c["type"] == "Ready"), None)
         return condition is not None and condition["status"] == "True"
 
+
 class Job(NamespacedAPIObject):
 
     version = "extensions/v1beta1"

--- a/pykube/objects.py
+++ b/pykube/objects.py
@@ -177,11 +177,12 @@ class Pod(NamespacedAPIObject):
         return condition is not None and condition["status"] == "True"
 
     def logs(self, container=None, pretty=None, previous=False,
-                 since_seconds=None, since_time=None, timestamps=False,
-                 tail_lines=None, limit_bytes=None):
+             since_seconds=None, since_time=None, timestamps=False,
+             tail_lines=None, limit_bytes=None):
         """
         Produces the same result as calling kubectl logs pod/<pod-name>.
-        Check parameters meaning at http://kubernetes.io/docs/api-reference/v1/operations/,
+        Check parameters meaning at
+        http://kubernetes.io/docs/api-reference/v1/operations/,
         part 'read log of the specified Pod'. The result is plain text.
         """
         url = "log"

--- a/pykube/objects.py
+++ b/pykube/objects.py
@@ -195,7 +195,7 @@ class Pod(NamespacedAPIObject):
         http://kubernetes.io/docs/api-reference/v1/operations/,
         part 'read log of the specified Pod'. The result is plain text.
         """
-        url = "log"
+        log_call = "log"
         params = {}
         if container is not None:
             params["container"] = container
@@ -215,14 +215,13 @@ class Pod(NamespacedAPIObject):
             params["limitBytes"] = int(limit_bytes)
 
         query_string = urlencode(params)
-        url += "?{}".format(query_string) if query_string else ""
+        log_call += "?{}".format(query_string) if query_string else ""
         kwargs = {
             "version": self.version,
-            "url": url,
             "namespace": self.namespace,
-            "operation": "pods/{}".format(self.name),
+            "operation": log_call,
         }
-        r = self.api.get(**kwargs)
+        r = self.api.get(**self.api_kwargs(**kwargs))
         r.raise_for_status()
         return r.text
 


### PR DESCRIPTION
Allows to retrieve logs for a Pod, in the same way as it is provided by `kubectl logs pod/<pod-name>`. Current implementation resides in the Pod object, although an alternative would be to have it done from the Query object. Should resolve issue #36 .