### PR TITLE
Some resources like Namespaces don't have a namespace

### DIFF
--- a/pykube/http.py
+++ b/pykube/http.py
@@ -77,10 +77,12 @@ class HTTPClient(object):
             base = kwargs.pop("base")
         bits = [base, version]
         if "namespace" in kwargs:
-            bits.extend([
-                "namespaces",
-                kwargs.pop("namespace"),
-            ])
+            namespace = kwargs.pop("namespace")
+            if namespace:
+                bits.extend([
+                    "namespaces",
+                    namespace,
+                ])
         url = kwargs.get("url", "")
         if url.startswith("/"):
             url = url[1:]


### PR DESCRIPTION
The api was being built wrongly thus the resource Namespace was broken

The api url was, for a 'build' namespace:

https://server.com/api/v1/namespaces/build/namespaces

But the right one is:
https://server.com/api/v1/namespaces/build