### PR TITLE
Support for extending resource api request urls

### DIFF
--- a/pykube/objects.py
+++ b/pykube/objects.py
@@ -1,6 +1,7 @@
 import copy
 import json
 import time
+import os.path as op
 
 import jsonpatch
 
@@ -35,11 +36,14 @@ class APIObject(object):
 
     def api_kwargs(self, **kwargs):
         kw = {}
-        collection = kwargs.pop("collection", False)
-        if collection:
+        # Construct url for api request
+        obj_list = kwargs.pop("obj_list", False)
+        if obj_list:
             kw["url"] = self.endpoint
         else:
-            kw["url"] = "{}/{}".format(self.endpoint, self._original_obj["metadata"]["name"])
+            operation = kwargs.pop("operation", "")
+            kw["url"] = op.normpath(op.join(self.endpoint, self.name, operation))
+
         if self.base:
             kw["base"] = self.base
         kw["version"] = self.version
@@ -60,7 +64,7 @@ class APIObject(object):
         return True
 
     def create(self):
-        r = self.api.post(**self.api_kwargs(data=json.dumps(self.obj), collection=True))
+        r = self.api.post(**self.api_kwargs(data=json.dumps(self.obj), obj_list=True))
         self.api.raise_for_status(r)
         self.set_obj(r.json())
 

--- a/pykube/objects.py
+++ b/pykube/objects.py
@@ -1,9 +1,6 @@
 import copy
 import json
-import time
 import os.path as op
-
-import jsonpatch
 
 from .exceptions import ObjectDoesNotExist
 from .mixins import ReplicatedMixin, ScalableMixin


### PR DESCRIPTION
Very basic tweak with potentially far-reaching consequences. Following specific changes:

- `api_kwargs` now accepts a new kwarg: `operations`. I'm totally not sold yet on that particular name, couldn't come up with anything better and will gladly change it to any cool suggestions from reviewers.
- `collections` kwarg to `api_kwargs` renamed to `obj_list`. I can undo this if it's likely to will affect many users downstream negatively, but I found that variable name a bit too _database_-y and not in line with k8s API's logic (ie. `PodList` etc). I figured I'd try sneaking a renaming in along with the other change.