### PR TITLE
Send a warning instead of raising an exception

### DIFF
--- a/pykube/http.py
+++ b/pykube/http.py
@@ -5,7 +5,7 @@ HTTP request related code.
 import posixpath
 import re
 import sys
-
+import warnings
 import requests
 
 from six.moves.urllib.parse import urlparse
@@ -40,7 +40,7 @@ class HTTPClient(object):
     def url(self, value):
         pr = urlparse(value)
         if sys.version_info < (3, 5) and ("::" in pr.hostname or _ipv4_re.match(pr.hostname)):
-            raise PyKubeError("IP address hostnames are not supported with Python < 3.5. Please see https://github.com/kelproject/pykube/issues/29 for more info.")
+            warnings.warn("IP address hostnames are not supported with Python < 3.5. Please see https://github.com/kelproject/pykube/issues/29 for more info.", RuntimeWarning)
         self._url = pr.geturl()
 
     def build_session(self):


### PR DESCRIPTION
8d29bb7 breaks some setups (e.g where session verify is overwritten by purpose).
This change sends a warning but does not raise.