### PR TITLE
Update config.py to handle relative paths

### DIFF
--- a/pykube/config.py
+++ b/pykube/config.py
@@ -208,7 +208,7 @@ class BytesOrFile(object):
         """
         self._filename = None
         self._bytes = None
-        if data.startswith("/"):
+        if os.path.isfile(data):
             self._filename = data
         else:
             self._bytes = base64.b64decode(data)


### PR DESCRIPTION
Checking if `data` is a file that exists (instead of just checking that it begins with a `/`) will allow for relative paths to files like `certificate-authority` in the kube config instead of forcing everything to be an absolute path.