### PR TITLE
Namespace from context

### DIFF
--- a/pykube/config.py
+++ b/pykube/config.py
@@ -109,7 +109,7 @@ class KubeConfig(object):
         Creates an instance of the KubeConfig class.
         """
         self.doc = doc
-        self.current_context = None
+        self._current_context = None
         if "current-context" in doc and doc["current-context"]:
             self.set_current_context(doc["current-context"])
 
@@ -120,7 +120,13 @@ class KubeConfig(object):
         :Parameters:
            - `value`: The value for the current context
         """
-        self.current_context = value
+        self._current_context = value
+
+    @property
+    def current_context(self):
+        if self._current_context is None:
+            raise exceptions.PyKubeError("current context not set; call set_current_context")
+        return self._current_context
 
     @property
     def clusters(self):
@@ -170,8 +176,6 @@ class KubeConfig(object):
         Returns the current selected cluster by exposing as a
         read-only property.
         """
-        if self.current_context is None:
-            raise exceptions.PyKubeError("current context not set; call set_current_context")
         return self.clusters[self.contexts[self.current_context]["cluster"]]
 
     @property
@@ -179,9 +183,14 @@ class KubeConfig(object):
         """
         Returns the current user by exposing as a read-only property.
         """
-        if self.current_context is None:
-            raise exceptions.PyKubeError("current context not set; call set_current_context")
         return self.users.get(self.contexts[self.current_context].get("user", ""), {})
+
+    @property
+    def namespace(self):
+        """
+        Returns the current context namespace by exposing as a read-only property.
+        """
+        return self.contexts[self.current_context].get("namespace", "")
 
     def persist_doc(self):
         if not hasattr(self, "filename") or not self.filename:

--- a/pykube/config.py
+++ b/pykube/config.py
@@ -190,7 +190,7 @@ class KubeConfig(object):
         """
         Returns the current context namespace by exposing as a read-only property.
         """
-        return self.contexts[self.current_context].get("namespace", "")
+        return self.contexts[self.current_context].get("namespace", "default")
 
     def persist_doc(self):
         if not hasattr(self, "filename") or not self.filename:

--- a/pykube/http.py
+++ b/pykube/http.py
@@ -69,17 +69,19 @@ class HTTPClient(object):
                 raise TypeError("unknown API version; base kwarg must be specified.")
             base = kwargs.pop("base")
         bits = [base, version]
-        if self.config.namespace:
-            namespace = self.config.namespace
+        # Overwrite (default) namespace from context if it was set
         if "namespace" in kwargs:
             n = kwargs.pop("namespace")
-            if n:
-                namespace = n
-        if namespace:
-            bits.extend([
-                "namespaces",
-                namespace,
-            ])
+            if n is not None:
+                if n:
+                    namespace = n
+                else:
+                    namespace = self.config.namespace
+                if namespace:
+                    bits.extend([
+                        "namespaces",
+                        namespace,
+                    ])
         url = kwargs.get("url", "")
         if url.startswith("/"):
             url = url[1:]

--- a/pykube/http.py
+++ b/pykube/http.py
@@ -69,13 +69,17 @@ class HTTPClient(object):
                 raise TypeError("unknown API version; base kwarg must be specified.")
             base = kwargs.pop("base")
         bits = [base, version]
+        if self.config.namespace:
+            namespace = self.config.namespace
         if "namespace" in kwargs:
-            namespace = kwargs.pop("namespace")
-            if namespace:
-                bits.extend([
-                    "namespaces",
-                    namespace,
-                ])
+            n = kwargs.pop("namespace")
+            if n:
+                namespace = n
+        if namespace:
+            bits.extend([
+                "namespaces",
+                namespace,
+            ])
         url = kwargs.get("url", "")
         if url.startswith("/"):
             url = url[1:]

--- a/pykube/query.py
+++ b/pykube/query.py
@@ -159,22 +159,6 @@ class WatchQuery(BaseQuery):
         return iter(self.object_stream())
 
 
-class ObjectManager(object):
-
-    def __init__(self, namespace=None):
-        self.namespace = namespace
-
-    def __call__(self, api, namespace=None):
-        if namespace is None:
-            namespace = self.namespace
-        return Query(api, self.api_obj_class, namespace=namespace)
-
-    def __get__(self, obj, api_obj_class):
-        assert obj is None, "cannot invoke objects on resource object."
-        self.api_obj_class = api_obj_class
-        return self
-
-
 def as_selector(value):
     if isinstance(value, str):
         return value

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -109,3 +109,9 @@ class TestConfig(TestCase):
         test_config = config.KubeConfig.from_file(DEFAULTUSER_CONFIG_FILE_PATH)
         test_config.set_current_context("a_context")
         self.assertIsNotNone(test_config.user)
+
+    def test_namespace(self):
+        self.cfg.set_current_context("thename")
+        self.assertEqual("default", self.cfg.namespace)
+        self.cfg.set_current_context("context_with_namespace")
+        self.assertEqual("foospace", self.cfg.namespace)

--- a/test/test_config.yaml
+++ b/test/test_config.yaml
@@ -12,3 +12,6 @@ contexts:
         user: admin
     - name: second
       context: secondcontext
+    - name: context_with_namespace
+      context:
+        namespace: foospace


### PR DESCRIPTION
I would like to implement the behavior of
`kubectl config set-context "$context" --namespace="$namespace"`

@brosner This is not enough due to the way `DEFAULT_NAMESPACE` is used to initialize `ObjectManager` for `NamespacedAPIObject`. Do you have an idea how to solve this?
