### PR TITLE
Add the HTTP status code to HTTPError

### DIFF
--- a/pykube/exceptions.py
+++ b/pykube/exceptions.py
@@ -18,7 +18,9 @@ class PyKubeError(KubernetesError):
 
 
 class HTTPError(PyKubeError):
-    pass
+    def __init__(self, code, message):
+        super(HTTPError, self).__init__(message)
+        self.code = code
 
 
 class ObjectDoesNotExist(PyKubeError):

--- a/pykube/http.py
+++ b/pykube/http.py
@@ -105,7 +105,7 @@ class HTTPClient(object):
             if resp.headers["content-type"] == "application/json":
                 payload = resp.json()
                 if payload["kind"] == "Status":
-                    raise HTTPError(payload["message"])
+                    raise HTTPError(resp.status_code, payload["message"])
             raise
 
     def request(self, *args, **kwargs):


### PR DESCRIPTION
This is useful for reacting to HTTP errors, e.g. trying a create() and
falling back to update() if a 409 is returned.