### PR TITLE
Adding support for RBAC resources

### DIFF
--- a/pykube/__init__.py
+++ b/pykube/__init__.py
@@ -25,5 +25,9 @@ from .objects import (  # noqa
     Service,
     ServiceAccount,
     ThirdPartyResource,
+    Role,
+    ClusterRole,
+    RoleBinding,
+    ClusterRoleBinding,
 )
 from .query import now, all_ as all, everything  # noqa

--- a/pykube/objects.py
+++ b/pykube/objects.py
@@ -292,3 +292,31 @@ class PetSet(NamespacedAPIObject):
     version = "apps/v1alpha1"
     endpoint = "petsets"
     kind = "PetSet"
+
+
+class Role(NamespacedAPIObject):
+
+    version = "rbac.authorization.k8s.io/v1alpha1"
+    endpoint = "roles"
+    kind = "Role"
+
+
+class RoleBinding(NamespacedAPIObject):
+
+    version = "rbac.authorization.k8s.io/v1alpha1"
+    endpoint = "rolebindings"
+    kind = "RoleBinding"
+
+
+class ClusterRole(APIObject):
+
+    version = "rbac.authorization.k8s.io/v1alpha1"
+    endpoint = "clusterroles"
+    kind = "ClusterRole"
+
+
+class ClusterRoleBinding(APIObject):
+
+    version = "rbac.authorization.k8s.io/v1alpha1"
+    endpoint = "clusterrolebindings"
+    kind = "ClusterRoleBinding"


### PR DESCRIPTION
Although the feature is in alpha version is fully functional and the RBAC resources (roles, rolebindings, clusterroles and clusterrolebindings) will be kept for future versions.