### PR TITLE
Add rollout undo feature support

### DIFF
--- a/pykube/objects.py
+++ b/pykube/objects.py
@@ -136,6 +136,33 @@ class Deployment(NamespacedAPIObject, ReplicatedMixin, ScalableMixin):
             self.obj["status"]["updatedReplicas"] == self.replicas
         )
 
+    def rollout_undo(self, target_revision=None):
+        """Produces same action as kubectl rollout undo deployment command.
+        Input variable is revision to rollback to (in kubectl, --to-revision)
+        """
+        if target_revision is None:
+            revision = {}
+        else:
+            revision = {
+                "revision": target_revision
+            }
+
+        params = {
+            "kind": "DeploymentRollback",
+            "apiVersion": self.version,
+            "name": self.name,
+            "rollbackTo": revision
+        }
+
+        kwargs = {
+            "version": self.version,
+            "namespace": self.namespace,
+            "operation": "rollback",
+        }
+        r = self.api.post(**self.api_kwargs(data=json.dumps(params), **kwargs))
+        r.raise_for_status()
+        return r.text
+
 
 class Endpoint(NamespacedAPIObject):
 


### PR DESCRIPTION
Adds support for the rollout undo command (reverts a previous Deployment update), with identical behavior to
`kubectl rollout undo deployment xxx`
URL syntax is similar to pod logging, so based this off of the logging implementation.

Usage is `pykube.Deployment(kubeapi, obj).rollout_undo(target_revision)`
