### PR TITLE
add version property for retrieving API version

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -126,6 +126,13 @@ Delete a ReplicationController:
     }
     pykube.ReplicationController(api, obj).delete()
 
+Check server version:
+
+.. code:: python
+
+    api = pykube.HTTPClient(pykube.KubeConfig.from_file("/Users/<username>/.kube/config"))
+    api.version
+
 Requirements
 ------------
 

--- a/pykube/http.py
+++ b/pykube/http.py
@@ -52,6 +52,15 @@ class HTTPClient(object):
             warnings.warn("IP address hostnames are not supported with Python < 3.5. Please see https://github.com/kelproject/pykube/issues/29 for more info.", RuntimeWarning)
         self._url = pr.geturl()
 
+    @property
+    def version(self):
+        """
+        Get Kubernetes API version
+        """
+        response = self.get('/version')
+        data = response.json()
+        return (data['major'], data['minor'])
+
     def get_kwargs(self, **kwargs):
         """
         Creates a full URL to request based on arguments.


### PR DESCRIPTION
This allows users of this client library the ability to check the server version and handle use cases such as when the HorizontalPodAutoscaler switched over the [endpoint version](https://github.com/kelproject/pykube/blob/cd5b511474bf8854d122af371681fb1dc467a1b9/pykube/objects.py#L325) from `extensions/v1beta1` to `autoscaling/v1`.