### PR TITLE
Fix pykube cert handling for Python versions < 3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * `HTTPClient` learned to handle GKE OAuth authentication
 * `Pod` learned to retrieve logs for containers
 * `Query.filter` learned to scope based on fields
+* Fixed handling of Kubernetes certificates for Python versions < 3.5
 
 ## 0.13.0
 

--- a/pykube/http.py
+++ b/pykube/http.py
@@ -4,8 +4,6 @@ HTTP request related code.
 
 import posixpath
 import re
-import sys
-import warnings
 
 from six.moves.urllib.parse import urlparse
 
@@ -48,8 +46,6 @@ class HTTPClient(object):
     @url.setter
     def url(self, value):
         pr = urlparse(value)
-        if sys.version_info < (3, 5) and ("::" in pr.hostname or _ipv4_re.match(pr.hostname)):
-            warnings.warn("IP address hostnames are not supported with Python < 3.5. Please see https://github.com/kelproject/pykube/issues/29 for more info.", RuntimeWarning)
         self._url = pr.geturl()
 
     def get_kwargs(self, **kwargs):

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     zip_safe=False,
     packages=find_packages(),
     install_requires=[
-        "requests",
+        "requests>=2.12",
         "requests-oauthlib",
         "PyYAML",
         "six",


### PR DESCRIPTION
Requests v2.12 has just been pushed to pypi.

This is the first version that contains urllib3 >= 1.18, which contains the fix https://github.com/shazow/urllib3/issues/258 adding support for IP Subject Alternate Names.

This fixes https://github.com/kelproject/pykube/issues/29 (which though closed, didn't actually have a proper resolution, until the urllib3 fix percolated into requests).

