### PR TITLE
Added StatefulSet object to objects, imported into __init__.

### DIFF
--- a/pykube/__init__.py
+++ b/pykube/__init__.py
@@ -24,6 +24,7 @@ from .objects import (  # noqa
     Secret,
     Service,
     ServiceAccount,
+    StatefulSet,
     ThirdPartyResource,
     Role,
     ClusterRole,

--- a/pykube/objects.py
+++ b/pykube/objects.py
@@ -334,6 +334,13 @@ class PetSet(NamespacedAPIObject):
     kind = "PetSet"
 
 
+class StatefulSet(NamespacedAPIObject):
+
+    version = "apps/v1beta1"
+    endpoint = "statefulsets"
+    kind = "StatefulSet"
+
+
 class Role(NamespacedAPIObject):
 
     version = "rbac.authorization.k8s.io/v1alpha1"


### PR DESCRIPTION
Kubernetes 1.5 came out a few days ago which includes changes to PetSets

Petsets are now called StatefulSets
* are now kind: StatefulSets
* use version: 'apps/v1beta1'
* use endpoint: 'statefulsets'

I just added a new class for StatefulSet and imported it into the package namespace.