### PR TITLE
fix response items from Nonetype to empty list

### DIFF
--- a/pykube/query.py
+++ b/pykube/query.py
@@ -118,6 +118,8 @@ class Query(BaseQuery):
         if not hasattr(self, "_query_cache"):
             cache = {"objects": []}
             cache["response"] = self.execute().json()
+            if cache["response"]["items"] is None:
+                cache["response"]["items"] = []
             for obj in cache["response"]["items"]:
                 cache["objects"].append(self.api_obj_class(self.api, obj))
             self._query_cache = cache


### PR DESCRIPTION
In case empty resorces return None rather than empty list in query_cache.