### PR TITLE
Require six version of 1.10.0 or greater for @six.python_2_unicode_co…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
         "requests>=2.12",
         "requests-oauthlib",
         "PyYAML",
-        "six",
+        "six>=1.10.0",
         "tzlocal",
         "oauth2client",
     ],


### PR DESCRIPTION
Require six version of 1.10.0 or greater for `@six.python_2_unicode_compatible`

In debian jessie, the stock version of six is 1.8.0.  Installing pykube in a container without upgrading six then leads to an exception (relevent portion below).

```python
File "/usr/local/lib/python3.4/dist-packages/pykube/__init__.py", line 8, in <module>
  from .objects import (  # noqa
File "/usr/local/lib/python3.4/dist-packages/pykube/objects.py", line 26, in <module>
  @six.python_2_unicode_compatible
AttributeError: 'module' object has no attribute 'python_2_unicode_compatible'
```

Upgrading six to 1.10.0 resolves the issue