### PR TITLE
Add ability to follow logs with Pod.logs

### DIFF
--- a/pykube/objects.py
+++ b/pykube/objects.py
@@ -307,7 +307,7 @@ class Pod(NamespacedAPIObject):
 
     def logs(self, container=None, pretty=None, previous=False,
              since_seconds=None, since_time=None, timestamps=False,
-             tail_lines=None, limit_bytes=None):
+             tail_lines=None, limit_bytes=None, follow=False):
         """
         Produces the same result as calling kubectl logs pod/<pod-name>.
         Check parameters meaning at
@@ -332,6 +332,8 @@ class Pod(NamespacedAPIObject):
             params["tailLines"] = int(tail_lines)
         if limit_bytes is not None:
             params["limitBytes"] = int(limit_bytes)
+        if follow:
+            params["follow"] = "true"
 
         query_string = urlencode(params)
         log_call += "?{}".format(query_string) if query_string else ""


### PR DESCRIPTION
This param was missing from the log method. Adding it should allow for the equivalent of `kubecl logs -f <pod_name>`