### PR TITLE
Add ready property to replication controller class

### DIFF
--- a/pykube/objects.py
+++ b/pykube/objects.py
@@ -351,6 +351,13 @@ class ReplicationController(NamespacedAPIObject, ReplicatedMixin, ScalableMixin)
     endpoint = "replicationcontrollers"
     kind = "ReplicationController"
 
+    @property
+    def ready(self):
+        return (
+            self.obj['status']['observedGeneration'] >= self.obj['metadata']['generation'] and
+            self.obj['status']['readyReplicas'] == self.replicas
+        )
+
 
 class ReplicaSet(NamespacedAPIObject, ReplicatedMixin, ScalableMixin):
 


### PR DESCRIPTION
This method is available on both pods and deployments. No reason we can't have it on RC's as well. I've currently got this method monkey patched on to `pykube.ReplicationController` in my project. Seems to be working well.