### PR TITLE
Test if selector is instance of str in backwards compatible way

### DIFF
--- a/pykube/query.py
+++ b/pykube/query.py
@@ -2,6 +2,7 @@ import json
 
 from collections import namedtuple
 
+from six import string_types
 from six.moves.urllib.parse import urlencode
 
 from .exceptions import ObjectDoesNotExist
@@ -167,7 +168,7 @@ class WatchQuery(BaseQuery):
 
 
 def as_selector(value):
-    if isinstance(value, str):
+    if isinstance(value, string_types):
         return value
     s = []
     for k, v in value.items():


### PR DESCRIPTION
In python2 it's possible to pass a `unicode` string as a selector, which doesn't trigger this condition, causing an error. By using `six.string_types` instead of `str` we make sure to test for both kinds of strings.