### PR TITLE
Allow custom base when watching resources

### DIFF
--- a/pykube/query.py
+++ b/pykube/query.py
@@ -152,6 +152,8 @@ class WatchQuery(BaseQuery):
             "url": self._build_api_url(params=params),
             "stream": True,
         }
+        if self.api_obj_class.base:
+            kwargs["base"] = self.api_obj_class.base
         if self.namespace is not all_:
             kwargs["namespace"] = self.namespace
         if self.api_obj_class.version:


### PR DESCRIPTION
Without this patch I wasn't able to watch resources where a custom base is set.