### PR TITLE
Have WatchQuery class respect base attribute of object class

### DIFF
--- a/pykube/query.py
+++ b/pykube/query.py
@@ -156,6 +156,8 @@ class WatchQuery(BaseQuery):
             kwargs["namespace"] = self.namespace
         if self.api_obj_class.version:
             kwargs["version"] = self.api_obj_class.version
+        if self.api_obj_class.base:
+            kwargs["base"] = self.api_obj_class.base
         r = self.api.get(**kwargs)
         self.api.raise_for_status(r)
         WatchEvent = namedtuple("WatchEvent", "type object")


### PR DESCRIPTION
This solves #152 with the same implementation as every other place where parameters are calculated to send through the API.