### PR TITLE
return resp.content instead of resp.text for logs

### DIFF
--- a/pykube/objects.py
+++ b/pykube/objects.py
@@ -367,7 +367,7 @@ class Pod(NamespacedAPIObject):
         }
         r = self.api.get(**self.api_kwargs(**kwargs))
         r.raise_for_status()
-        return r.text
+        return r.content
 
 
 class ReplicationController(NamespacedAPIObject, ReplicatedMixin, ScalableMixin):


### PR DESCRIPTION
requests will treat content encoding as ISO-8859-1 when encoding is not
present in response header, which cause resp.text messed up.